### PR TITLE
Create reusable question feedback component

### DIFF
--- a/src/blocks/bulb-ma/index.js
+++ b/src/blocks/bulb-ma/index.js
@@ -10,6 +10,7 @@ import Inspector from './inspector';
 import Controls from './controls';
 import QuestionHeader from '../../components/QuestionHeader';
 import QuestionBody from '../../components/QuestionBody';
+import QuestionFeedback from '../../components/QuestionFeedback';
 
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
@@ -45,6 +46,8 @@ export default registerBlockType( 'bulb/question-ma', {
 				header,
 				body,
 				answers,
+				correctFeedback,
+				incorrectFeedback,
 				fontSize,
 				textAlignment,
 				textColorControl,
@@ -61,20 +64,9 @@ export default registerBlockType( 'bulb/question-ma', {
 			} );
 		}
 
-		// Handle input field changes
-		const onChangeHeader = newHeader => {
+		const onSimpleAttributeChange = attribute => value => {
 			setAttributes( {
-				header: newHeader,
-			} );
-		};
-		const onChangeBody = newBody => {
-			setAttributes( {
-				body: newBody,
-			} );
-		};
-		const onChangeAnswers = newAnswers => {
-			setAttributes( {
-				answers: newAnswers,
+				[ attribute ]: value,
 			} );
 		};
 
@@ -85,26 +77,46 @@ export default registerBlockType( 'bulb/question-ma', {
 					<div id={ id } className={ classnames( 'question', className ) }>
 						<QuestionHeader
 							value={ header }
-							onChange={ onChangeHeader }
-							textAlignment={ textAlignment }
-							textColorControl={ textColorControl }
-							backgroundColorControl={ backgroundColorControl }
-							fontSize={ fontSize }
+							onChange={ onSimpleAttributeChange( 'header' ) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 						<QuestionBody
 							value={ body }
-							onChange={ onChangeBody }
-							textAlignment={ textAlignment }
-							textColorControl={ textColorControl }
-							backgroundColorControl={ backgroundColorControl }
-							fontSize={ fontSize }
+							onChange={ onSimpleAttributeChange( 'body' ) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 						<Answers
 							answers={ answers }
-							onChangeAnswers={ onChangeAnswers }
+							onChangeAnswers={ onSimpleAttributeChange( 'answers' ) }
 							multipleCorrectAllowed={ true }
 							minAnswers={ 2 }
 							maxAnswers={ 6 }
+						/>
+						<QuestionFeedback
+							correctFeedback={ correctFeedback }
+							onCorrectFeedbackChange={ onSimpleAttributeChange(
+								'correctFeedback'
+							) }
+							incorrectFeedback={ incorrectFeedback }
+							onIncorrectFeedbackChange={ onSimpleAttributeChange(
+								'incorrectFeedback'
+							) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 					</div>
 					<Controls { ...{ setAttributes, ...props } } />

--- a/src/blocks/bulb-ma/index.php
+++ b/src/blocks/bulb-ma/index.php
@@ -32,10 +32,12 @@ function bulb_render_block_ma( $attributes, $content ) {
 
 	// Transform gutenberg attributes into the proposed data structure.
 	$data = [
-		'type'    => 'multiple-answer',
-		'header'  => do_shortcode( $attributes['header'] ),
-		'body'    => do_shortcode( $attributes['body'] ),
-		'answers' => $attributes['answers'],
+		'type'              => 'multiple-answer',
+		'header'            => do_shortcode( $attributes['header'] ),
+		'body'              => do_shortcode( $attributes['body'] ),
+		'answers'           => $attributes['answers'],
+		'correctFeedback'   => do_shortcode( $attributes['correctFeedback'] ),
+		'incorrectFeedback' => do_shortcode( $attributes['incorrectFeedback'] ),
 	];
 
 	// Save the block data as a JS variable.
@@ -73,6 +75,8 @@ function bulb_register_question_ma() {
 						],
 					],
 				],
+				'correctFeedback'        => [],
+				'incorrectFeedback'      => [],
 				'textAlignment'          => [
 					'default' => 'left',
 				],

--- a/src/blocks/bulb-mc/index.js
+++ b/src/blocks/bulb-mc/index.js
@@ -10,6 +10,7 @@ import Inspector from './inspector';
 import Controls from './controls';
 import QuestionHeader from '../../components/QuestionHeader';
 import QuestionBody from '../../components/QuestionBody';
+import QuestionFeedback from '../../components/QuestionFeedback';
 
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
@@ -45,6 +46,8 @@ export default registerBlockType( 'bulb/question-mc', {
 				header,
 				body,
 				answers,
+				correctFeedback,
+				incorrectFeedback,
 				fontSize,
 				textAlignment,
 				textColorControl,
@@ -61,20 +64,9 @@ export default registerBlockType( 'bulb/question-mc', {
 			} );
 		}
 
-		// Handle input field changes
-		const onChangeHeader = newHeader => {
+		const onSimpleAttributeChange = attribute => value => {
 			setAttributes( {
-				header: newHeader,
-			} );
-		};
-		const onChangeBody = newBody => {
-			setAttributes( {
-				body: newBody,
-			} );
-		};
-		const onChangeAnswers = newAnswers => {
-			setAttributes( {
-				answers: newAnswers,
+				[ attribute ]: value,
 			} );
 		};
 
@@ -85,26 +77,46 @@ export default registerBlockType( 'bulb/question-mc', {
 					<div id={ id } className={ classnames( 'question', className ) }>
 						<QuestionHeader
 							value={ header }
-							onChange={ onChangeHeader }
-							textAlignment={ textAlignment }
-							textColorControl={ textColorControl }
-							backgroundColorControl={ backgroundColorControl }
-							fontSize={ fontSize }
+							onChange={ onSimpleAttributeChange( 'header' ) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 						<QuestionBody
 							value={ body }
-							onChange={ onChangeBody }
-							textAlignment={ textAlignment }
-							textColorControl={ textColorControl }
-							backgroundColorControl={ backgroundColorControl }
-							fontSize={ fontSize }
+							onChange={ onSimpleAttributeChange( 'body' ) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 						<Answers
 							answers={ answers }
-							onChangeAnswers={ onChangeAnswers }
+							onChangeAnswers={ onSimpleAttributeChange( 'answers' ) }
 							multipleCorrectAllowed={ false }
 							minAnswers={ 2 }
 							maxAnswers={ 6 }
+						/>
+						<QuestionFeedback
+							correctFeedback={ correctFeedback }
+							onCorrectFeedbackChange={ onSimpleAttributeChange(
+								'correctFeedback'
+							) }
+							incorrectFeedback={ incorrectFeedback }
+							onIncorrectFeedbackChange={ onSimpleAttributeChange(
+								'incorrectFeedback'
+							) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 					</div>
 					<Controls { ...{ setAttributes, ...props } } />

--- a/src/blocks/bulb-mc/index.php
+++ b/src/blocks/bulb-mc/index.php
@@ -32,10 +32,12 @@ function bulb_render_block_mc( $attributes, $content ) {
 
 	// Transform gutenberg attributes into the proposed data structure.
 	$data = [
-		'type'    => 'multiple-choice',
-		'header'  => do_shortcode( $attributes['header'] ),
-		'body'    => do_shortcode( $attributes['body'] ),
-		'answers' => $attributes['answers'],
+		'type'              => 'multiple-choice',
+		'header'            => do_shortcode( $attributes['header'] ),
+		'body'              => do_shortcode( $attributes['body'] ),
+		'answers'           => $attributes['answers'],
+		'correctFeedback'   => do_shortcode( $attributes['correctFeedback'] ),
+		'incorrectFeedback' => do_shortcode( $attributes['incorrectFeedback'] ),
 	];
 
 	// Save the block data as a JS variable.
@@ -73,6 +75,8 @@ function bulb_register_question_mc() {
 						],
 					],
 				],
+				'correctFeedback'        => [],
+				'incorrectFeedback'      => [],
 				'textAlignment'          => [
 					'default' => 'left',
 				],

--- a/src/blocks/bulb-tf/index.js
+++ b/src/blocks/bulb-tf/index.js
@@ -10,6 +10,7 @@ import Inspector from './inspector';
 import Controls from './controls';
 import QuestionHeader from '../../components/QuestionHeader';
 import QuestionBody from '../../components/QuestionBody';
+import QuestionFeedback from '../../components/QuestionFeedback';
 
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
@@ -45,6 +46,8 @@ export default registerBlockType( 'bulb/question-tf', {
 				header,
 				body,
 				answers,
+				correctFeedback,
+				incorrectFeedback,
 				fontSize,
 				textAlignment,
 				textColorControl,
@@ -61,22 +64,12 @@ export default registerBlockType( 'bulb/question-tf', {
 			} );
 		}
 
-		// Handle input field changes
-		const onChangeHeader = newHeader => {
+		const onSimpleAttributeChange = attribute => value => {
 			setAttributes( {
-				header: newHeader,
+				[ attribute ]: value,
 			} );
 		};
-		const onChangeBody = newBody => {
-			setAttributes( {
-				body: newBody,
-			} );
-		};
-		const onChangeAnswers = newAnswers => {
-			setAttributes( {
-				answers: newAnswers,
-			} );
-		};
+
 		return (
 			<div className="quizDescription">
 				<Fragment>
@@ -84,26 +77,46 @@ export default registerBlockType( 'bulb/question-tf', {
 					<div id={ id } className={ classnames( 'question', className ) }>
 						<QuestionHeader
 							value={ header }
-							onChange={ onChangeHeader }
-							textAlignment={ textAlignment }
-							textColorControl={ textColorControl }
-							backgroundColorControl={ backgroundColorControl }
-							fontSize={ fontSize }
+							onChange={ onSimpleAttributeChange( 'header' ) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 						<QuestionBody
 							value={ body }
-							onChange={ onChangeBody }
-							textAlignment={ textAlignment }
-							textColorControl={ textColorControl }
-							backgroundColorControl={ backgroundColorControl }
-							fontSize={ fontSize }
+							onChange={ onSimpleAttributeChange( 'body' ) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 						<Answers
 							answers={ answers }
-							onChangeAnswers={ onChangeAnswers }
+							onChangeAnswers={ onSimpleAttributeChange( 'answers' ) }
 							multipleCorrectAllowed={ false }
 							minAnswers={ 2 }
 							maxAnswers={ 2 }
+						/>
+						<QuestionFeedback
+							correctFeedback={ correctFeedback }
+							onCorrectFeedbackChange={ onSimpleAttributeChange(
+								'correctFeedback'
+							) }
+							incorrectFeedback={ incorrectFeedback }
+							onIncorrectFeedbackChange={ onSimpleAttributeChange(
+								'incorrectFeedback'
+							) }
+							{ ...{
+								textAlignment,
+								textColorControl,
+								backgroundColorControl,
+								fontSize,
+							} }
 						/>
 					</div>
 					<Controls { ...{ setAttributes, ...props } } />

--- a/src/blocks/bulb-tf/index.php
+++ b/src/blocks/bulb-tf/index.php
@@ -33,10 +33,12 @@ function bulb_render_block_tf( $attributes, $content ) {
 
 	// Transform gutenberg attributes into the proposed data structure.
 	$data = [
-		'type'    => 'true-false',
-		'header'  => do_shortcode( $attributes['header'] ),
-		'body'    => do_shortcode( $attributes['body'] ),
-		'answers' => $attributes['answers'],
+		'type'              => 'true-false',
+		'header'            => do_shortcode( $attributes['header'] ),
+		'body'              => do_shortcode( $attributes['body'] ),
+		'answers'           => $attributes['answers'],
+		'correctFeedback'   => do_shortcode( $attributes['correctFeedback'] ),
+		'incorrectFeedback' => do_shortcode( $attributes['incorrectFeedback'] ),
 	];
 
 	// Save the block data as a JS variable.
@@ -74,6 +76,8 @@ function bulb_register_question_tf() {
 						],
 					],
 				],
+				'correctFeedback'        => [],
+				'incorrectFeedback'      => [],
 				'textAlignment'          => [
 					'default' => 'left',
 				],

--- a/src/components/QuestionFeedback.js
+++ b/src/components/QuestionFeedback.js
@@ -1,0 +1,40 @@
+import EnhancedRichText from './EnhancedRichText';
+
+const { __ } = wp.i18n;
+
+export default props => {
+	if ( props.singleFeedback ) {
+		return (
+			<div>
+				<h5>{ __( 'Feedback:', 'bulearningblocks' ) }</h5>
+				<EnhancedRichText
+					className="question-feedback"
+					placeholder={ __( 'Enter Feedback', 'bulearningblocks' ) }
+					value={ props.feedback }
+					onChange={ props.onFeedbackChange }
+					{ ...props }
+				/>
+			</div>
+		);
+	}
+	return (
+		<div>
+			<h5>{ __( 'Correct Feedback:', 'bulearningblocks' ) }</h5>
+			<EnhancedRichText
+				className="question-feedback"
+				placeholder={ __( 'Enter Correct Feedback', 'bulearningblocks' ) }
+				value={ props.correctFeedback }
+				onChange={ props.onCorrectFeedbackChange }
+				{ ...props }
+			/>
+			<h5>{ __( 'Incorrect Feedback:', 'bulearningblocks' ) }</h5>
+			<EnhancedRichText
+				className="question-feedback"
+				placeholder={ __( 'Enter Incorrect Feedback', 'bulearningblocks' ) }
+				value={ props.incorrectFeedback }
+				onChange={ props.onIncorrectFeedbackChange }
+				{ ...props }
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
This pr creates a reusable question feedback component and makes use of it across all question types (tf, mc, ma).

It also reduces some amount of repetition by creating a helper method to generate simple onChange handlers. `onSimpleAttributeChange( '<attribute-name>' )` returns a simple onChange function that takes a value and calls setAttribute to update the specified `<attribute-name>` with that new value.