### PR TITLE
Case sensitivity

### DIFF
--- a/data-structure.md
+++ b/data-structure.md
@@ -337,7 +337,7 @@
 
 ``` json
 {
-  "quesstion": {
+  "question": {
     "type": "fill-in-the-blank",
     "header": "Type in the word exactly in lower case",
     "body": "What is the Spanish word for grandmother?",

--- a/data-structure.md
+++ b/data-structure.md
@@ -314,3 +314,39 @@
   }
 }
 ```
+
+## Question: Fill in the Blank
+
+```json
+{
+  "question": {
+    "type": "fill-in-the-blank",
+    "header": "String",
+    "body": "String",
+    "answer": "String",
+    "caseSensitive": "Boolean",
+    "feedback": {
+      "correct": "String",
+      "incorrect": "String"
+    }
+  }
+}
+```
+
+### Fill in the Blank Example
+
+``` json
+{
+  "quesstion": {
+    "type": "fill-in-the-blank",
+    "header": "Type in the word exactly in lower case",
+    "body": "What is the Spanish word for grandmother?",
+    "answer": "abuela",
+    "caseSensitive": true,
+    "feedback": {
+      "correct": "Yes, that is correct",
+      "incorrect": "No, that is not the exact lower case spelling",
+    }
+  }
+}
+```

--- a/src/blocks/bulb-fitb/index.js
+++ b/src/blocks/bulb-fitb/index.js
@@ -4,6 +4,8 @@
 const { __ } = wp.i18n;
 const { registerBlockType } = wp.blocks;
 const { Fragment } = wp.element;
+const { InspectorControls } = wp.editor;
+const { PanelBody, PanelRow, FormToggle } = wp.components;
 
 import Question from '../../components/Question';
 import Controls from '../../components/Controls';
@@ -33,6 +35,7 @@ export default registerBlockType( 'bulb/question-fitb', {
 				body,
 				answer,
 				feedback,
+				caseSensitive,
 				fontSize,
 				textAlignment,
 				textColorControl,
@@ -54,8 +57,27 @@ export default registerBlockType( 'bulb/question-fitb', {
 			} );
 		};
 
+		const toggleCaseSensitivity = event => setAttributes( { caseSensitive: event.target.checked } );
+
 		return (
 			<div className="bulb-question-fitb">
+				<InspectorControls>
+					<PanelBody>
+						<PanelRow>
+							<label
+								htmlFor="bulb-fitb-case-sensitivity"
+							>
+								{ __( 'Case sensitivity', 'bulearningblocks' ) }
+							</label>
+							<FormToggle
+								id="bulb-fitb-case-sensitivity"
+								label={ __( 'Case sensitivity', 'bulearningblocks' ) }
+								checked={ caseSensitive }
+								onChange={ toggleCaseSensitivity }
+							/>
+						</PanelRow>
+					</PanelBody>
+				</InspectorControls>
 				<Fragment>
 					<Controls { ...props } />
 					<Question

--- a/src/blocks/bulb-fitb/index.js
+++ b/src/blocks/bulb-fitb/index.js
@@ -57,7 +57,7 @@ export default registerBlockType( 'bulb/question-fitb', {
 			} );
 		};
 
-		const toggleCaseSensitivity = event => setAttributes( { caseSensitive: event.target.checked } );
+		const toggleCaseSensitivity = event => setAttributes( { caseSensitive: !! event.target.checked } );
 
 		return (
 			<div className="bulb-question-fitb">

--- a/src/blocks/bulb-fitb/index.php
+++ b/src/blocks/bulb-fitb/index.php
@@ -66,6 +66,9 @@ function bulb_register_question_fitb() {
 				'answer'                 => [
 					'default' => '',
 				],
+				'caseSensitive'          => [
+					'default' => true,
+				],
 				'feedback'               => [
 					'default' => [
 						'correct'   => '',

--- a/src/blocks/bulb-fitb/index.php
+++ b/src/blocks/bulb-fitb/index.php
@@ -32,11 +32,12 @@ function bulb_render_block_fitb( $attributes, $content ) {
 
 	// Transform gutenberg attributes into the front-end data structure.
 	$data = [
-		'type'     => $attributes['type'],
-		'header'   => do_shortcode( $attributes['header'] ),
-		'body'     => do_shortcode( $attributes['body'] ),
-		'answer'   => $attributes['answer'],
-		'feedback' => $attributes['feedback'],
+		'type'          => $attributes['type'],
+		'header'        => do_shortcode( $attributes['header'] ),
+		'body'          => do_shortcode( $attributes['body'] ),
+		'answer'        => $attributes['answer'],
+		'caseSensitive' => $attributes['caseSensitive'],
+		'feedback'      => $attributes['feedback'],
 	];
 
 	// Save the block data as a JS variable.

--- a/src/frontend.js
+++ b/src/frontend.js
@@ -112,5 +112,10 @@ function parseHTMLStringsCalculatedNumeric( questionData ) {
 
 function parseHTMLStringsFillInTheBlank( questionData ) {
 	const parsedQuestionData = parseHTMLStringsCommon( questionData );
+
+	// Ugly patch for boolean difficulties with wp_localize_script.
+	// Look at using wp_add_inline_instead.
+	parsedQuestionData.caseSensitive = !! parsedQuestionData.caseSensitive;
+
 	return parsedQuestionData;
 }


### PR DESCRIPTION
Adds a toggle in the Fill in the Blank block inspector to optionally set a `caseSensitive` flag to the front end question renderer.  A [corresponding change in bu-react-questions](https://github.com/bu-ist/bu-react-questions/pull/19) can consume this flag and optionally allow case insensitive answer checking.

As part of this work, we discovered that `wp_localize_script` doesn't work well with Boolean values.  As [mentioned in trac ticket 25280](https://core.trac.wordpress.org/ticket/25280) we should switch to using `wp_add_inline_script` which is more designed for what we are doing with it (passing JSON objects to front end React).

The structure of the 2 functions is slightly different, so this PR doesn't address this issue.  See #73 for follow up.