### PR TITLE
Improve labels in post taxonomy editor

### DIFF
--- a/src/customize_tax_panel.js
+++ b/src/customize_tax_panel.js
@@ -1,5 +1,14 @@
 var el = wp.element.createElement;
 
+/**
+ * Customizes the label within the taxonomy editor component.
+ *
+ * @since 0.0.7
+ *
+ * @param {Component} OriginalComponent Post taxonomy editor component.
+ *
+ * @returns {Component} The customized editor component.
+ */
 function customizeLessonSelector( OriginalComponent ) {
 	return function( props ) {
 		if ( props.slug === 'bulb-courses' ) {

--- a/src/customize_tax_panel.js
+++ b/src/customize_tax_panel.js
@@ -1,0 +1,20 @@
+var el = wp.element.createElement;
+
+function customizeLessonSelector( OriginalComponent ) {
+	return function( props ) {
+		if ( props.slug === 'bulb-courses' ) {
+			// Customize the label for the custom taxonomy.
+			props.taxonomy.labels.add_new_item = 'Include in Lesson (start typing name of Lesson)';
+		}
+		return el(
+			OriginalComponent,
+			props
+		);
+	};
+}
+
+wp.hooks.addFilter(
+	'editor.PostTaxonomyType',
+	'bu-learning-blocks',
+	customizeLessonSelector
+);

--- a/src/learning-module-cpt.php
+++ b/src/learning-module-cpt.php
@@ -209,3 +209,19 @@ function remove_bulb_attributes_panel() {
 if ( class_exists( 'BU_Navigation_Plugin' ) ) {
 	add_action( 'enqueue_block_editor_assets', 'remove_bulb_attributes_panel' );
 }
+
+/**
+ * Load script to customize the taxonomy menu in the lesson page editor.
+ *
+ * @since 0.0.7
+ */
+function bulb_add_admin_scripts() {
+	wp_enqueue_script(
+		'customize_tax_panel',
+		BULB_PLUGIN_URL . 'src/customize_tax_panel.js',
+		array(),
+		filemtime( plugin_dir_path( __DIR__ ) . 'src/customize_tax_panel.js' ), // Gets file modification time for cache busting.
+		true // Enqueue the script in the footer.
+	);
+}
+add_action( 'enqueue_block_editor_assets', 'bulb_add_admin_scripts' );


### PR DESCRIPTION
Introduces a hook that modifies the default post taxonomy editor to improve the label.

It is based on an [example in the Gutenberg repo](https://github.com/WordPress/gutenberg/tree/c24882bc3a81bad12c1c367b2cc9ae982d1a8605/packages/editor/src/components/post-taxonomies#custom-taxonomy-selector).

The JS component is not going through webpack currently, so it uses ES5 syntax (like `var` which doesn't lint well) for compatibility.