### PR TITLE
Fix attribute types

### DIFF
--- a/src/blocks/bulb-cn/index.php
+++ b/src/blocks/bulb-cn/index.php
@@ -59,38 +59,56 @@ function bulb_register_question_cn() {
 	register_block_type(
 		'bulb/question-cn', [
 			'attributes'      => [
-				'id'                     => [],
+				'id'                     => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'type'                   => [
 					'default' => 'calculated-numeric',
+					'type'    => 'string',
 				],
-				'header'                 => [],
-				'body'                   => [],
+				'header'                 => [
+					'default' => '',
+					'type'    => 'string',
+				],
+				'body'                   => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'answer'                 => [
 					'default' => '0.0',
+					'type'    => 'string',
 				],
 				'answerRange'            => [
 					'default' => '0.1',
+					'type'    => 'string',
 				],
 				'decimalPlaces'          => [
 					'default' => 3,
+					'type'    => 'integer',
 				],
 				'feedback'               => [
 					'default' => [
 						'correct'   => '',
 						'incorrect' => '',
 					],
+					'type'    => 'object',
 				],
 				'textAlignment'          => [
 					'default' => 'left',
+					'type'    => 'string',
 				],
 				'backgroundColorControl' => [
-					'type' => 'string',
+					'default' => 'left',
+					'type'    => 'string',
 				],
 				'textColorControl'       => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'fontSize'               => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 			],
 			'render_callback' => 'bulb_render_block_cn',

--- a/src/blocks/bulb-fitb/index.php
+++ b/src/blocks/bulb-fitb/index.php
@@ -58,35 +58,52 @@ function bulb_register_question_fitb() {
 	register_block_type(
 		'bulb/question-fitb', [
 			'attributes'      => [
-				'id'                     => [],
+				'id'                     => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'type'                   => [
 					'default' => 'fill-in-the-blank',
+					'type'    => 'string',
 				],
-				'header'                 => [],
-				'body'                   => [],
+				'header'                 => [
+					'default' => '',
+					'type'    => 'string',
+				],
+				'body'                   => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'answer'                 => [
 					'default' => '',
+					'type'    => 'string',
 				],
 				'caseSensitive'          => [
 					'default' => true,
+					'type'    => 'boolean',
 				],
 				'feedback'               => [
 					'default' => [
 						'correct'   => '',
 						'incorrect' => '',
 					],
+					'type'    => 'array',
 				],
 				'textAlignment'          => [
 					'default' => 'left',
+					'type'    => 'string',
 				],
 				'backgroundColorControl' => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'textColorControl'       => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'fontSize'               => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 			],
 			'render_callback' => 'bulb_render_block_fitb',

--- a/src/blocks/bulb-fitb/index.php
+++ b/src/blocks/bulb-fitb/index.php
@@ -87,7 +87,7 @@ function bulb_register_question_fitb() {
 						'correct'   => '',
 						'incorrect' => '',
 					],
-					'type'    => 'array',
+					'type'    => 'object',
 				],
 				'textAlignment'          => [
 					'default' => 'left',

--- a/src/blocks/bulb-ma/index.php
+++ b/src/blocks/bulb-ma/index.php
@@ -101,7 +101,7 @@ function bulb_register_question_ma() {
 					'type' => 'string',
 				],
 			],
-			'render_callback' => 'bulb_render_block_mc',
+			'render_callback' => 'bulb_render_block_ma',
 		]
 	);
 }

--- a/src/blocks/bulb-ma/index.php
+++ b/src/blocks/bulb-ma/index.php
@@ -62,12 +62,22 @@ function bulb_register_question_ma() {
 	register_block_type(
 		'bulb/question-ma', [
 			'attributes'      => [
-				'id'                     => [],
+				'id'                     => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'type'                   => [
 					'default' => 'multiple-answer',
+					'type'    => 'string',
 				],
-				'header'                 => [],
-				'body'                   => [],
+				'header'                 => [
+					'default' => '',
+					'type'    => 'string',
+				],
+				'body'                   => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'answers'                => [
 					'default' => [
 						[
@@ -81,24 +91,33 @@ function bulb_register_question_ma() {
 							'correct'  => false,
 						],
 					],
+					'type'    => 'array',
+					'items'   => [
+						'type' => 'object',
+					],
 				],
 				'feedback'               => [
 					'default' => [
 						'correct'   => '',
 						'incorrect' => '',
 					],
+					'type'    => 'object',
 				],
 				'textAlignment'          => [
 					'default' => 'left',
+					'type'    => 'string',
 				],
 				'backgroundColorControl' => [
-					'type' => 'string',
+					'default' => 'left',
+					'type'    => 'string',
 				],
 				'textColorControl'       => [
-					'type' => 'string',
+					'default' => 'left',
+					'type'    => 'string',
 				],
 				'fontSize'               => [
-					'type' => 'string',
+					'default' => 'left',
+					'type'    => 'string',
 				],
 			],
 			'render_callback' => 'bulb_render_block_ma',

--- a/src/blocks/bulb-mat/index.php
+++ b/src/blocks/bulb-mat/index.php
@@ -62,12 +62,22 @@ function bulb_register_question_mat() {
 	register_block_type(
 		'bulb/question-mat', [
 			'attributes'      => [
-				'id'                     => [],
+				'id'                     => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'type'                   => [
 					'default' => 'matching',
+					'type'    => 'string',
 				],
-				'header'                 => [],
-				'body'                   => [],
+				'header'                 => [
+					'default' => '',
+					'type'    => 'string',
+				],
+				'body'                   => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'answers'                => [
 					'default' => [
 						[
@@ -81,24 +91,33 @@ function bulb_register_question_mat() {
 							'correct'  => 'A',
 						],
 					],
+					'type'    => 'array',
+					'items'   => [
+						'type' => 'object',
+					],
 				],
 				'feedback'               => [
 					'default' => [
 						'correct'   => '',
 						'incorrect' => '',
 					],
+					'type'    => 'object',
 				],
 				'textAlignment'          => [
 					'default' => 'left',
+					'type'    => 'string',
 				],
 				'backgroundColorControl' => [
-					'type' => 'string',
+					'default' => 'left',
+					'type'    => 'string',
 				],
 				'textColorControl'       => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'fontSize'               => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 			],
 			'render_callback' => 'bulb_render_block_mc',

--- a/src/blocks/bulb-mc/index.php
+++ b/src/blocks/bulb-mc/index.php
@@ -62,12 +62,22 @@ function bulb_register_question_mc() {
 	register_block_type(
 		'bulb/question-mc', [
 			'attributes'      => [
-				'id'                     => [],
+				'id'                     => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'type'                   => [
 					'default' => 'multiple-choice',
+					'type'    => 'string',
 				],
-				'header'                 => [],
-				'body'                   => [],
+				'header'                 => [
+					'default' => '',
+					'type'    => 'string',
+				],
+				'body'                   => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'answers'                => [
 					'default' => [
 						[
@@ -81,24 +91,33 @@ function bulb_register_question_mc() {
 							'correct'  => false,
 						],
 					],
+					'type'    => 'array',
+					'items'   => [
+						'type' => 'object',
+					],
 				],
 				'feedback'               => [
 					'default' => [
 						'correct'   => '',
 						'incorrect' => '',
 					],
+					'type'    => 'object',
 				],
 				'textAlignment'          => [
 					'default' => 'left',
+					'type'    => 'string',
 				],
 				'backgroundColorControl' => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'textColorControl'       => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'fontSize'               => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 			],
 			'render_callback' => 'bulb_render_block_mc',

--- a/src/blocks/bulb-tf/index.php
+++ b/src/blocks/bulb-tf/index.php
@@ -63,14 +63,22 @@ function bulb_register_question_tf() {
 	register_block_type(
 		'bulb/question-tf', [
 			'attributes'      => [
-				'id'                     => [],
+				'id'                     => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'type'                   => [
 					'default' => 'true-false',
+					'type'    => 'string',
 				],
 				'header'                 => [
 					'default' => 'Is the following statement true or false',
+					'type'    => 'string',
 				],
-				'body'                   => [],
+				'body'                   => [
+					'default' => '',
+					'type'    => 'string',
+				],
 				'answers'                => [
 					'default' => [
 						[
@@ -84,24 +92,33 @@ function bulb_register_question_tf() {
 							'correct'  => false,
 						],
 					],
+					'type'    => 'array',
+					'items'   => [
+						'type' => 'object',
+					],
 				],
 				'feedback'               => [
 					'default' => [
 						'correct'   => '',
 						'incorrect' => '',
 					],
+					'type'    => 'object',
 				],
 				'textAlignment'          => [
 					'default' => 'left',
+					'type'    => 'string',
 				],
 				'backgroundColorControl' => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'textColorControl'       => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 				'fontSize'               => [
-					'type' => 'string',
+					'default' => '',
+					'type'    => 'string',
 				],
 			],
 			'render_callback' => 'bulb_render_block_tf',


### PR DESCRIPTION
Fixes #76

Also patches a typo in the bulb-ma question where it was using the bulb-mc render function.

I tested this will the 6 question types and everything appeared to render correctly.  I'm not seeing any undefined notices.