### PR TITLE
Change bulb-courses taxonomy slug.

### DIFF
--- a/src/learning-module-cpt.php
+++ b/src/learning-module-cpt.php
@@ -32,7 +32,7 @@ function register_course_tax() {
 		'not_found'                  => __( 'Not Found', 'bulearningblocks' ),
 	);
 	$rewrite = array(
-		'slug'       => 'courses',
+		'slug'       => 'lesson',
 		'with_front' => false,
 	);
 	$args    = array(


### PR DESCRIPTION
The use of 'courses'  was deemed confusing by stakeholders. Use 'lesson ' instead.