### PR TITLE
Place a sidebar on CPT activation 

### DIFF
--- a/src/init.php
+++ b/src/init.php
@@ -52,6 +52,31 @@ add_action( 'admin_post_install_cpt', 'bulb_admin_install_cpt' );
  */
 function bulb_admin_install_cpt() {
 	update_option( 'bulb_cpt_install', 1 );
+
+	// If BULB is activated with a responsive-framework theme, place a sidebar nav widget.
+	if ( in_array(
+		get_template(),
+		array( 'responsive-framework', 'responsive-framework-2-x' ),
+		true
+	) ) {
+		$sidebars = get_option( 'sidebars_widgets' );
+
+		// Add a BU Navigation widget to the posts sidebar.
+		$sidebars['posts'] = array_merge( $sidebars['posts'], [ 'bu_pages-1' ] );
+		update_option( 'sidebars_widgets', $sidebars );
+
+		// BU Navigation widget settings, defaults from Responsive Framework.
+		update_option( 'widget_bu_pages', array(
+			'_multiwidget' => 1,
+			1              => array(
+				'navigation_title'      => 'section',
+				'navigation_title_text' => '',
+				'navigation_title_url'  => '',
+				'navigation_style'      => 'section',
+			),
+		) );
+	}
+
 	wp_safe_redirect( 'plugins.php' );
 	exit;
 }


### PR DESCRIPTION
If a responsive-framework theme is detected, this code writes to the wp options table to place a BU Nav widget in the `posts` sidebar.

Since individual themes have different ways of defining sidebars, it's not straightforward to programmatically add a widget in a way that works for any theme.  This approach should work for the responsive-framework 2.x family of themes.

It is similar to [activation code in responsive-framework itself](https://github.com/bu-ist/responsive-framework/blob/master/bu-site-init.php#L80-L98), and uses the widget defaults used there.

