### PR TITLE
Fix version label in main plugin file

### DIFF
--- a/bu-learning-blocks.php
+++ b/bu-learning-blocks.php
@@ -9,7 +9,7 @@
  * Author URI: http://www.bu.edu/
  * Text Domain: bu-learning-blocks
  * Domain Path: /languages
- * Version: v1.1.1
+ * Version: 1.1.1
  * License: GPL2+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  *


### PR DESCRIPTION
To correct the following error when submitting to the WordPress plugin directory:

Error: Plugin versions are expected to be numbers. Version strings may only contain numeric and period characters (i.e. 1.2). Please correct the Version: line in your main plugin file and upload the plugin again.