### PR TITLE
Add wordpress.org publish action

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,7 @@
+/.wordpress-org
+/.git
+/.github
+/node_modules
+
+.distignore
+.gitignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Directories
+/.wordpress-org export-ignore
+/.github export-ignore
+
+# Files
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,16 @@
+name: Deploy to WordPress.org
+on:
+  push:
+    tags:
+    - "*"
+jobs:
+  tag:
+    name: New tag
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: WordPress Plugin Deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      env:
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
Adds a [Github action](https://github.com/marketplace/actions/wordpress-plugin-deploy) from the 10Up WordPress Github actions collection.  This uses secret SVN credentials in the repo to publish the plugin to the wordpress.org plugin directory whenever a new tag is created.

This is only related to the build system, and has no impact on the plugin code.